### PR TITLE
Ignore busybox when setting up PATH

### DIFF
--- a/jobs/collectd/templates/helpers/ctl_setup.sh
+++ b/jobs/collectd/templates/helpers/ctl_setup.sh
@@ -12,6 +12,7 @@
 
 set -e # exit immediately if a simple command exits with a non-zero status
 set -u # report the usage of uninitialized variables
+shopt -s extglob # so we can ignore busybox when globbing
 
 JOB_NAME=$1
 output_label=${1:-JOB_NAME}
@@ -30,13 +31,13 @@ redirect_output ${output_label}
 export HOME=${HOME:-/home/vcap}
 
 # Add all packages' /bin & /sbin into $PATH
-for package_bin_dir in $(ls -d /var/vcap/packages/*/*bin)
+for package_bin_dir in $(ls -d /var/vcap/packages/!(busybox)/*bin)
 do
   export PATH=${package_bin_dir}:$PATH
 done
 
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-''} # default to empty
-for package_bin_dir in $(ls -d /var/vcap/packages/*/lib)
+for package_bin_dir in $(ls -d /var/vcap/packages/!(busybox)/lib)
 do
   export LD_LIBRARY_PATH=${package_bin_dir}:$LD_LIBRARY_PATH
 done


### PR DESCRIPTION
Without this if busybox is installed on a system it will add the busybox
/bin directory full of broken symlinks to PATH, and all future commands
will fail. The symlinks are broken because they're absolute and expect
/bin/ to be in the root of a container, which we are not operating in.
