### PR TITLE
Fix ctl setup

### DIFF
--- a/jobs/collectd/templates/helpers/ctl_setup.sh
+++ b/jobs/collectd/templates/helpers/ctl_setup.sh
@@ -70,7 +70,7 @@ PIDFILE=$RUN_DIR/$JOB_NAME.pid
 # Add all packages' /bin & /sbin into $PATH
 for package_bin_dir in $(ls -d /var/vcap/packages/!(busybox)/*bin)
 do
-  export PATH=${package_bin_dir}:$PATH
+  export PATH=$PATH:${package_bin_dir}
 done
 
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-''} # default to empty

--- a/jobs/collectd/templates/helpers/ctl_setup.sh
+++ b/jobs/collectd/templates/helpers/ctl_setup.sh
@@ -30,18 +30,6 @@ redirect_output ${output_label}
 
 export HOME=${HOME:-/home/vcap}
 
-# Add all packages' /bin & /sbin into $PATH
-for package_bin_dir in $(ls -d /var/vcap/packages/!(busybox)/*bin)
-do
-  export PATH=${package_bin_dir}:$PATH
-done
-
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-''} # default to empty
-for package_bin_dir in $(ls -d /var/vcap/packages/!(busybox)/lib)
-do
-  export LD_LIBRARY_PATH=${package_bin_dir}:$LD_LIBRARY_PATH
-done
-
 # Setup log, run and tmp folders
 
 export RUN_DIR=/var/vcap/sys/run/$JOB_NAME
@@ -78,5 +66,17 @@ do
 done
 
 PIDFILE=$RUN_DIR/$JOB_NAME.pid
+
+# Add all packages' /bin & /sbin into $PATH
+for package_bin_dir in $(ls -d /var/vcap/packages/!(busybox)/*bin)
+do
+  export PATH=${package_bin_dir}:$PATH
+done
+
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-''} # default to empty
+for package_bin_dir in $(ls -d /var/vcap/packages/!(busybox)/lib)
+do
+  export LD_LIBRARY_PATH=${package_bin_dir}:$LD_LIBRARY_PATH
+done
 
 echo '$PATH' $PATH

--- a/jobs/collectd/templates/helpers/ctl_setup.sh
+++ b/jobs/collectd/templates/helpers/ctl_setup.sh
@@ -12,6 +12,7 @@
 
 set -e # exit immediately if a simple command exits with a non-zero status
 set -u # report the usage of uninitialized variables
+shopt -s extglob # so we can ignore busybox when globbing
 
 JOB_NAME=$1
 output_label=${1:-JOB_NAME}
@@ -30,13 +31,13 @@ redirect_output ${output_label}
 export HOME=${HOME:-/home/vcap}
 
 # Add all packages' /bin & /sbin into $PATH
-for package_bin_dir in $(ls -d /var/vcap/packages/*/*bin)
+for package_bin_dir in $(ls -d /var/vcap/packages/!(busybox)/*bin)
 do
   export PATH=${package_bin_dir}:$PATH
 done
 
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-''} # default to empty
-for package_bin_dir in $(ls -d /var/vcap/packages/*/lib)
+for package_bin_dir in $(ls -d /var/vcap/packages/!(busybox)/lib)
 do
   export LD_LIBRARY_PATH=${package_bin_dir}:$LD_LIBRARY_PATH
 done

--- a/jobs/collectd/templates/helpers/ctl_setup.sh
+++ b/jobs/collectd/templates/helpers/ctl_setup.sh
@@ -76,7 +76,10 @@ done
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-''} # default to empty
 for package_bin_dir in $(ls -d /var/vcap/packages/!(busybox)/lib)
 do
-  export LD_LIBRARY_PATH=${package_bin_dir}:$LD_LIBRARY_PATH
+  # do not include a package with ld-*.so as it is likely a rootfs
+  if [ -z "$(find ${package_bin_dir} -name 'ld-*.so' -o -name 'ld64-*.so')" ]; then
+      export LD_LIBRARY_PATH=${package_bin_dir}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+  fi
 done
 
 echo '$PATH' $PATH


### PR DESCRIPTION
Fix some aspects of ctl_setup.sh script:
- move setting of LD_LIBRARY_PATH and PATH to the end of the script, so that it doesn't affect commands of the script
- add a filter to LD_LIBRARY_PATH package selection to exclude packages that look to be a rootfs type
- append to PATH, so that stemcell system level packages get used first in the helper scripts

For more details see commit messages.

This PR depends on/contains https://github.com/cloudfoundry-community/collectd-boshrelease/pull/9
