### PR TITLE
Deploy yajl package with collectd job

### DIFF
--- a/jobs/collectd/spec
+++ b/jobs/collectd/spec
@@ -2,6 +2,7 @@
 name: collectd
 packages:
   - collectd
+  - yajl
 templates:
   bin/monit_debugger: bin/monit_debugger
   bin/collectd_ctl: bin/collectd_ctl


### PR DESCRIPTION
libyajl shared-objects are a runtime dependency if you want to use
the curl_json plugin.  I assume someone at some point in time wanted
to use this because they went through the hassle of compiling collectd
with support for it, and modifying the collectd monit scripts to add
the yajl package path to LD_LIBRARY_PATH, but without this spec change,
the libyajl shared-objects don't make it onto the system, leaving
curl_json plugin unable to initialize.

I want to use curl_json plugin to collect cell advertised capacity by
watching http://[cell-ip]:1800/state